### PR TITLE
add .gitattributes file to handle eol by project setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+template_body.txt text eol=lf
+template_request.txt text eol=lf
+template_signature.txt text eol=lf


### PR DESCRIPTION
it fix problem with calculated hashes for template file content (with eol=lf)
now template files are alway in working directory with lf without dependency on OS or local git setup